### PR TITLE
add mysql string escaping for add_admin_user

### DIFF
--- a/features/typo3.feature
+++ b/features/typo3.feature
@@ -79,7 +79,7 @@ Feature: Test tasks for namespace 'typo3:cms'
 		When I successfully run `cap dev "typo3:cms:create_install_tool_password_file[super-secret-password]"`
 		Then a remote file named "shared_path/config/install_tool_password.php" should exist
 
-	Scenario: Check adding a TYPO3 admin user
+	Scenario: Check adding a TYPO3 admin user interactively
 		Given I want to use the database `dkdeploy_typo3_cms`
 		Given the TYPO3 table be_users exists
 		When I run `cap dev typo3:cms:create_db_credentials` interactively
@@ -98,3 +98,40 @@ Feature: Test tasks for namespace 'typo3:cms'
 		And I wait 10 second to let the database commit the transaction
 		Then the database should have a value `admin` in table `be_users` for column `username`
 		Then the database should have a value `2304d4770a72d09106045fea654c4188` in table `be_users` for column `password`
+
+	Scenario: Check adding a Typo3 admin user with a string that needs escaping
+		Given I want to use the database `dkdeploy_typo3_cms`
+		Given the TYPO3 table be_users exists
+		When I run `cap dev typo3:cms:create_db_credentials` interactively
+		And I type "127.0.0.1"
+		And I type "3306"
+		And I type "dkdeploy_typo3_cms"
+		And I type "root"
+		And I type "ilikerandompasswords"
+		And I type "utf8"
+		And I close the stdin stream
+		Then the exit status should be 0
+		When I run `cap dev "typo3:cms:add_admin_user[dkd-admin,DROP TABLE be_users;this')s_a/very_"nasty"\string]"`
+		And I wait 10 second to let the database commit the transaction
+		Then the database should have a value `dkd-admin` in table `be_users` for column `username`
+		Then the database should have a value `857ea8fba149f63590e290ffe69bd33d` in table `be_users` for column `password`
+
+	Scenario: Check adding a Typo3 admin user with a string that needs escaping interactively
+		Given I want to use the database `dkdeploy_typo3_cms`
+		Given the TYPO3 table be_users exists
+		When I run `cap dev typo3:cms:create_db_credentials` interactively
+		And I type "127.0.0.1"
+		And I type "3306"
+		And I type "dkdeploy_typo3_cms"
+		And I type "root"
+		And I type "ilikerandompasswords"
+		And I type "utf8"
+		And I close the stdin stream
+		Then the exit status should be 0
+		When I run `cap dev typo3:cms:add_admin_user` interactively
+		And I type "dkd-admin"
+		And I type "DROP TABLE be_users;this')s_a/very_nasty\string"
+		And I close the stdin stream
+		And I wait 10 second to let the database commit the transaction
+		Then the database should have a value `dkd-admin` in table `be_users` for column `username`
+		Then the database should have a value `a4525cc4adb871fd961be1ffb22be712` in table `be_users` for column `password`

--- a/lib/dkdeploy/typo3/cms/helpers/mysql.rb
+++ b/lib/dkdeploy/typo3/cms/helpers/mysql.rb
@@ -1,0 +1,26 @@
+module Dkdeploy
+  module Typo3
+    module Cms
+      module Helpers
+        # MySQL Helpers
+        module Mysql
+          # Escape special character in string for MySQL.
+          # copied from https://github.com/tmtm/ruby-mysql/blob/2.9.14/lib/mysql.rb#L56
+          # @param [String]
+          # @return [String]
+          def mysql_escape_string(str)
+            str.gsub(/[\0\n\r\\\'\"\x1a]/) do |s|
+              case s
+              when "\0" then '\\0'
+              when "\n" then '\\n'
+              when "\r" then '\\r'
+              when "\x1a" then '\\Z'
+              else "\\#{s}"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dkdeploy/typo3/cms/tasks/typo3.rake
+++ b/lib/dkdeploy/typo3/cms/tasks/typo3.rake
@@ -3,6 +3,7 @@ require 'digest/md5'
 require 'dkdeploy/typo3/cms/dsl'
 require 'dkdeploy/typo3/cms/i18n'
 require 'dkdeploy/helpers/common'
+require 'dkdeploy/typo3/cms/helpers/mysql'
 require 'dkdeploy/interaction_handler/password'
 require 'phpass'
 require 'shellwords'
@@ -12,6 +13,7 @@ require 'dkdeploy/typo3/cms/helpers/erb'
 
 include Dkdeploy::Typo3::Cms::Helpers::Erb
 include Dkdeploy::Helpers::Common
+include Dkdeploy::Typo3::Cms::Helpers::Mysql
 include Dkdeploy::Typo3::DSL
 
 namespace :typo3 do
@@ -158,7 +160,7 @@ namespace :typo3 do
       now = Time.now.to_i
 
       sql_string = "INSERT INTO be_users (username, password, admin, tstamp, crdate)
-                      VALUES ('#{typo3_username}', MD5('#{typo3_password}'), 1, #{now}, #{now});"
+                   VALUES ('#{mysql_escape_string typo3_username}', MD5('#{mysql_escape_string typo3_password}'), 1, #{now}, #{now});"
 
       on primary :backend do
         begin


### PR DESCRIPTION
Adds a helper method for MySQL string escaping. This method is then used in the `add_admin_user` task.
Tests are added that show in which cases this was an issue.

test plan: `cucumber`