### PR TITLE
[TASK] use public_path for uploading typo3 related files

### DIFF
--- a/lib/dkdeploy/typo3/cms/tasks/cache.rake
+++ b/lib/dkdeploy/typo3/cms/tasks/cache.rake
@@ -5,8 +5,10 @@ namespace :typo3 do
     namespace :cache do
       desc 'Clear TYPO3 file cache directory'
       task :clear_file_cache do |task|
+        remote = fetch(:remote_web_root_path, '.')
+
         on release_roles :app do
-          cache_path = File.join release_path, 'typo3temp', 'var', 'Cache'
+          cache_path = File.join release_path, remote, 'typo3temp', 'var', 'Cache'
           execute :rm, '-rf', cache_path if test "[ -d #{cache_path} ]"
         end
 

--- a/lib/dkdeploy/typo3/cms/tasks/typo3.rake
+++ b/lib/dkdeploy/typo3/cms/tasks/typo3.rake
@@ -20,15 +20,18 @@ namespace :typo3 do
   namespace :cms do
     desc 'Clear typo3temp directory'
     task :clear_typo3temp do
+      remote = fetch(:remote_web_root_path, '.')
+
       on release_roles :app do
         info I18n.t('tasks.clear_temp.clear', scope: :dkdeploy)
-        execute :rm, '-rf', File.join(release_path, 'typo3temp', '*')
+        execute :rm, '-rf', File.join(release_path, remote, 'typo3temp', '*')
       end
     end
 
     desc 'Disable TYPO3 install tool'
     task :disable_install_tool do
-      flag = File.join(current_path, 'typo3conf', 'ENABLE_INSTALL_TOOL')
+      remote = fetch(:remote_web_root_path, '.')
+      flag   = File.join(current_path, remote, 'typo3conf', 'ENABLE_INSTALL_TOOL')
 
       on release_roles :app do
         if test "[ -f #{flag} ]"
@@ -40,10 +43,12 @@ namespace :typo3 do
 
     desc 'Enable TYPO3 install tool'
     task :enable_install_tool do
+      remote = fetch(:remote_web_root_path, '.')
+
       on release_roles :app do
         info I18n.t('tasks.install_tool.enable', scope: :dkdeploy)
-        execute :mkdir, '-p', File.join(current_path, 'typo3conf')
-        execute :touch, File.join(current_path, 'typo3conf', 'ENABLE_INSTALL_TOOL')
+        execute :mkdir, '-p', File.join(current_path, remote, 'typo3conf')
+        execute :touch, File.join(current_path, remote, 'typo3conf', 'ENABLE_INSTALL_TOOL')
       end
     end
 
@@ -78,14 +83,17 @@ namespace :typo3 do
 
     desc 'Download extension to local workspace'
     task :fetch_extension, :extension do |_, args|
+      copy_source = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+      remote    = fetch(:remote_web_root_path, '.')
       extension = ask_variable(args, :extension, 'tasks.fetch_extension.extension_name')
+
       FileUtils.mkdir_p File.join('temp', 'extensions')
       FileUtils.remove_dir File.join('temp', 'extensions', extension), true
-      source = File.join(current_path, 'typo3conf', 'ext', extension)
+      source = File.join(current_path, remote, 'typo3conf', 'ext', extension)
       target = File.join('temp', 'extensions')
 
       on primary(:backend) do
-        if test "[ -d #{File.join(current_path, 'typo3conf', 'ext', extension)} ]"
+        if test "[ -d #{File.join(current_path, remote, 'typo3conf', 'ext', extension)} ]"
           # download to temp
           info I18n.t('tasks.fetch_extension.download', extension: extension, scope: :dkdeploy)
           download! source, target, via: :scp, recursive: true
@@ -103,7 +111,7 @@ namespace :typo3 do
         rsync_exclude_directories.each do |exclude|
           rsync_excludes << '--exclude=' + exclude
         end
-        execute :rsync, '-vrS', '--force', '-C', '--delete', rsync_excludes, File.join('temp', 'extensions', extension, '/'), File.join('htdocs', 'typo3conf', 'ext', extension, '/')
+        execute :rsync, '-vrS', '--force', '-C', '--delete', rsync_excludes, File.join('temp', 'extensions', extension, '/'), File.join(copy_source, 'typo3conf', 'ext', extension, '/')
       end
     end
 
@@ -222,6 +230,7 @@ namespace :typo3 do
 
     desc 'Remove not needed extensions'
     task :remove_extensions do
+      remote               = fetch(:remote_web_root_path, '.')
       installed_extensions = (capture_typo3_console_in_loop 1, 'extension:list', '--active', '--raw').split("\n")
 
       run_locally do
@@ -239,7 +248,7 @@ namespace :typo3 do
         unless extensions_to_remove.empty?
           info I18n.t('tasks.typo3.cms.v6.remove_extensions.info', scope: :dkdeploy, removed_extensions: extensions_to_remove.join(', '))
           extensions_to_remove.each do |extension|
-            execute :rm, '-rf', "#{release_path}/typo3conf/ext/#{extension}"
+            execute :rm, '-rf', File.join(release_path, remote, "typo3conf/ext", extension)
           end
         end
       end
@@ -261,8 +270,9 @@ namespace :typo3 do
 
     desc 'Sets up the TYPO3 6+ specific configuration for each stage'
     task :setup_additional_configuration, :additional_configuration_template do |_, args|
+      remote = fetch(:remote_web_root_path, '.')
       configuration_template = ask_variable(args, :additional_configuration_template, 'questions.additional_configuration_template')
-      remote_configuration_file = File.join(release_path, 'typo3conf', 'AdditionalConfiguration.php')
+      remote_configuration_file = File.join(release_path, remote, 'typo3conf', 'AdditionalConfiguration.php')
       unless File.exist?(configuration_template)
         run_locally do
           raise I18n.t('tasks.typo3.cms.v6.setup_additional_configuration.upload_info', configuration_template: configuration_template, scope: :dkdeploy)

--- a/lib/dkdeploy/typo3/cms/tasks/typoscript.rake
+++ b/lib/dkdeploy/typo3/cms/tasks/typoscript.rake
@@ -10,13 +10,14 @@ namespace :typo3 do
       desc "Uploads TypoScript config files from local paths prefixed by variable 'copy_source'"
       task :upload_configs, :copy_source, :typoscript_config_paths, :typoscript_config_file do |_, args|
         prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
         paths       = ask_array_variable(args, :typoscript_config_paths, 'tasks.typoscript.config_paths') { |question| question.default = '' }
         config_file = ask_variable(args, :typoscript_config_file, 'tasks.typoscript.config_file') { |question| question.default = 'config.txt' }
 
         paths.each do |path|
           local_path         = File.join(prefix, path)
           local_config_file  = File.join(local_path, config_file)
-          remote_path        = File.join(current_path, path)
+          remote_path        = File.join(current_path, remote, path)
           remote_config_file = File.join(remote_path, config_file)
 
           unless File.exist? local_config_file
@@ -38,13 +39,14 @@ namespace :typo3 do
       desc "Uploads PageTS files from local paths prefixed by variable 'copy_source'"
       task :upload_pagets, :copy_source, :typoscript_pagets_paths, :typoscript_pagets_file do |_, args|
         prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
         paths       = ask_array_variable(args, :typoscript_pagets_paths, 'tasks.typoscript.pagets_paths') { |question| question.default = '' }
         pagets_file = ask_variable(args, :typoscript_pagets_file, 'tasks.typoscript.pagets_file') { |question| question.default = 'PageTS.txt' }
 
         paths.each do |path|
           local_path         = File.join(prefix, path)
           local_pagets_file  = File.join(local_path, pagets_file)
-          remote_path        = File.join(current_path, path)
+          remote_path        = File.join(current_path, remote, path)
           remote_pagets_file = File.join(remote_path, pagets_file)
 
           unless File.exist? local_pagets_file
@@ -66,13 +68,14 @@ namespace :typo3 do
       desc "Uploads UserTS files from local paths prefixed by variable 'copy_source'"
       task :upload_userts, :copy_source, :typoscript_userts_paths, :typoscript_userts_file do |_, args|
         prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
         paths       = ask_array_variable(args, :typoscript_userts_paths, 'tasks.typoscript.userts_paths') { |question| question.default = '' }
         userts_file = ask_variable(args, :typoscript_userts_file, 'tasks.typoscript.userts_file') { |question| question.default = 'UserTS.txt' }
 
         paths.each do |path|
           local_path         = File.join(prefix, path)
           local_userts_file  = File.join(local_path, userts_file)
-          remote_path        = File.join(current_path, path)
+          remote_path        = File.join(current_path, remote, path)
           remote_userts_file = File.join(remote_path, userts_file)
 
           unless File.exist? local_userts_file
@@ -93,8 +96,9 @@ namespace :typo3 do
 
       desc 'Uploads all config files from given base path'
       task :upload_config_from_base_path, :copy_source, :typoscript_config_base_path, :typoscript_config_file do |_, args|
-        prefix = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
-        base_path = ask_variable(args, :typoscript_config_base_path, 'tasks.typoscript.typoscript_config_base_path') { |question| question.default = '.' }
+        prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_config_base_path, 'tasks.typoscript.typoscript_config_base_path') { |question| question.default = '.' }
         config_file = ask_variable(args, :typoscript_config_file, 'tasks.typoscript.config_file') { |question| question.default = 'config.txt' }
 
         config_files = Dir[File.join(prefix, base_path, '**', config_file).to_s].map { |path_for_config_file| Pathname.new(path_for_config_file).relative_path_from(Pathname.new(prefix)).dirname.to_s }
@@ -102,6 +106,7 @@ namespace :typo3 do
         next if config_files.empty?
 
         set :copy_source, prefix
+        set :remote_web_root_path, remote
         set :typoscript_config_paths, config_files
         set :typoscript_config_file, config_file
         invoke 'typo3:cms:typoscript:upload_configs'
@@ -109,14 +114,16 @@ namespace :typo3 do
 
       desc 'Uploads all PageTS files from given base path'
       task :upload_pagets_from_base_path, :copy_source, :typoscript_pagets_base_path, :typoscript_pagets_file do |_, args|
-        prefix = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
-        base_path = ask_variable(args, :typoscript_pagets_base_path, 'tasks.typoscript.typoscript_pagets_base_path') { |question| question.default = '.' }
+        prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_pagets_base_path, 'tasks.typoscript.typoscript_pagets_base_path') { |question| question.default = '.' }
         pagets_file = ask_variable(args, :typoscript_pagets_file, 'tasks.typoscript.pagets_file') { |question| question.default = 'PageTS.txt' }
 
         pagets_files = Dir[File.join(prefix, base_path, '**', pagets_file).to_s].map { |path_for_pagets_file| Pathname.new(path_for_pagets_file).relative_path_from(Pathname.new(prefix)).dirname.to_s }
         next if pagets_files.empty?
 
         set :copy_source, prefix
+        set :remote_web_root_path, remote
         set :typoscript_pagets_paths, pagets_files
         set :typoscript_pagets_file, pagets_file
         invoke 'typo3:cms:typoscript:upload_pagets'
@@ -124,14 +131,16 @@ namespace :typo3 do
 
       desc 'Uploads all UserTS files from given base path'
       task 'upload_userts_from_base_path', :copy_source, :typoscript_userts_base_path, :typoscript_userts_file do |_, args|
-        prefix = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
-        base_path = ask_variable(args, :typoscript_userts_base_path, 'tasks.typoscript.typoscript_userts_base_path') { |question| question.default = '.' }
+        prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_userts_base_path, 'tasks.typoscript.typoscript_userts_base_path') { |question| question.default = '.' }
         userts_file = ask_variable(args, :typoscript_userts_file, 'tasks.typoscript.userts_file') { |question| question.default = 'UserTS.txt' }
 
         userts_files = Dir[File.join(prefix, base_path, '**', userts_file).to_s].map { |path_for_userts_file| Pathname.new(path_for_userts_file).relative_path_from(Pathname.new(prefix)).dirname.to_s }
         next if userts_files.empty?
 
         set :copy_source, prefix
+        set :remote_web_root_path, remote
         set :typoscript_userts_paths, userts_files
         set :typoscript_userts_file, userts_file
         invoke 'typo3:cms:typoscript:upload_userts'
@@ -139,11 +148,12 @@ namespace :typo3 do
 
       desc 'Merge remote TypoScript config files'
       task :merge_configs, :typoscript_config_paths, :typoscript_config_file do |_, args|
-        paths = ask_array_variable(args, :typoscript_config_paths, 'tasks.typoscript.config_paths')
+        remote      = fetch(:remote_web_root_path, '.')
+        paths       = ask_array_variable(args, :typoscript_config_paths, 'tasks.typoscript.config_paths')
         config_file = ask_variable(args, :typoscript_config_file, 'tasks.typoscript.config_file') { |question| question.default = 'config.txt' }
 
         paths.each do |path|
-          path = File.join(release_path, path)
+          path = File.join(release_path, remote, path)
 
           target_config_file_with_stage_name = config_file.split('.').join(".#{fetch(:stage)}.")
           source_config_file = File.join(path, 'Stages', target_config_file_with_stage_name)
@@ -169,11 +179,12 @@ namespace :typo3 do
 
       desc 'Merge remote PageTS files'
       task :merge_pagets, :typoscript_pagets_paths, :typoscript_pagets_file do |_, args|
-        paths = ask_array_variable(args, :typoscript_pagets_paths, 'tasks.typoscript.pagets_paths')
+        remote      = fetch(:remote_web_root_path, '.')
+        paths       = ask_array_variable(args, :typoscript_pagets_paths, 'tasks.typoscript.pagets_paths')
         pagets_file = ask_variable(args, :typoscript_pagets_file, 'tasks.typoscript.pagets_file') { |question| question.default = 'PageTS.txt' }
 
         paths.each do |path|
-          path = File.join(release_path, path)
+          path = File.join(release_path, remote, path)
 
           target_pagets_file_with_stage_name = pagets_file.split('.').join(".#{fetch(:stage)}.")
           source_pagets_file = File.join(path, 'Stages', target_pagets_file_with_stage_name)
@@ -199,11 +210,12 @@ namespace :typo3 do
 
       desc 'Merge remote UserTS files'
       task :merge_userts, :typoscript_userts_paths, :typoscript_userts_file do |_, args|
-        paths = ask_array_variable(args, :typoscript_userts_paths, 'tasks.typoscript.userts_paths')
+        remote      = fetch(:remote_web_root_path, '.')
+        paths       = ask_array_variable(args, :typoscript_userts_paths, 'tasks.typoscript.userts_paths')
         userts_file = ask_variable(args, :typoscript_userts_file, 'tasks.typoscript.userts_file') { |question| question.default = 'UserTS.txt' }
 
         paths.each do |path|
-          path = File.join(release_path, path)
+          path = File.join(release_path, remote, path)
 
           target_userts_file_with_stage_name = userts_file.split('.').join(".#{fetch(:stage)}.")
           source_userts_file = File.join(path, 'Stages', target_userts_file_with_stage_name)
@@ -229,13 +241,14 @@ namespace :typo3 do
 
       desc 'Merge all remote config files for a given base path'
       task :merge_config_in_base_path, :typoscript_config_base_path, :typoscript_config_file do |_, args|
+        remote      = fetch(:remote_web_root_path, '.')
         base_path = ask_variable(args, :typoscript_config_base_path, 'tasks.typoscript.typoscript_config_base_path') { |question| question.default = '.' }
         config_file = ask_variable(args, :typoscript_config_file, 'tasks.typoscript.config_file') { |question| question.default = 'config.txt' }
 
         list_of_files = ''
         target_config_file_with_stage_name = config_file.split('.').join(".#{fetch(:stage)}.")
         on primary :app do
-          list_of_files = capture :find, File.join(release_path, base_path), '-type f', "-name '#{target_config_file_with_stage_name}'"
+          list_of_files = capture :find, File.join(release_path, remote, base_path), '-type f', "-name '#{target_config_file_with_stage_name}'"
         end
 
         next if list_of_files.empty?
@@ -248,13 +261,14 @@ namespace :typo3 do
 
       desc 'Merge all remote PageTS files for a given base path'
       task :merge_pagets_in_base_path, :typoscript_pagets_base_path, :typoscript_pagets_file do |_, args|
-        base_path = ask_variable(args, :typoscript_pagets_base_path, 'tasks.typoscript.typoscript_pagets_base_path') { |question| question.default = '.' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_pagets_base_path, 'tasks.typoscript.typoscript_pagets_base_path') { |question| question.default = '.' }
         pagets_file = ask_variable(args, :typoscript_pagets_file, 'tasks.typoscript.pagets_file') { |question| question.default = 'PageTS.txt' }
 
         list_of_files = ''
         target_pagets_file_with_stage_name = pagets_file.split('.').join(".#{fetch(:stage)}.")
         on primary :app do
-          list_of_files = capture :find, File.join(release_path, base_path), '-type f', "-name '#{target_pagets_file_with_stage_name}'"
+          list_of_files = capture :find, File.join(release_path, remote, base_path), '-type f', "-name '#{target_pagets_file_with_stage_name}'"
         end
 
         next if list_of_files.empty?
@@ -267,17 +281,18 @@ namespace :typo3 do
 
       desc 'Merge all remote UserTS files for a given bbase path'
       task :merge_userts_in_base_path, :typoscript_userts_base_path, :typoscript_userts_file do |_, args|
-        base_path = ask_variable(args, :typoscript_userts_base_path, 'tasks.typoscript.typoscript_userts_base_path') { |question| question.default = '.' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_userts_base_path, 'tasks.typoscript.typoscript_userts_base_path') { |question| question.default = '.' }
         userts_file = ask_variable(args, :typoscript_userts_file, 'tasks.typoscript.userts_file') { |question| question.default = 'UserTS.txt' }
 
         list_of_files = ''
         target_userts_file_with_stage_name = userts_file.split('.').join(".#{fetch(:stage)}.")
         on primary :app do
-          list_of_files = capture :find, File.join(release_path, base_path), '-type f', "-name '#{target_userts_file_with_stage_name}'"
+          list_of_files = capture :find, File.join(release_path, remote, base_path), '-type f', "-name '#{target_userts_file_with_stage_name}'"
         end
 
         next if list_of_files.empty?
-        userts_files = list_of_files.split.map { |file| Pathname.new(file).relative_path_from(Pathname.new(release_path)).dirname.dirname.to_s }
+        userts_files = list_of_files.split.map { |file| Pathname.new(file).relative_path_from(Pathname.new(release_path) + remote).dirname.dirname.to_s }
 
         set :typoscript_userts_paths, userts_files
         set :typoscript_userts_file, userts_file

--- a/vendor/AdditionalConfiguration.php.erb
+++ b/vendor/AdditionalConfiguration.php.erb
@@ -1,7 +1,7 @@
 <?php
-<% if File.exist?(File.join('htdocs', 'typo3conf', 'AdditionalConfiguration.php')) %>
+<% if File.exist?(File.join(fetch(:local_web_root_path), 'typo3conf', 'AdditionalConfiguration.php')) %>
 // Content of default configuration file
-<%= sanitize_php File.read(File.join('htdocs', 'typo3conf', 'AdditionalConfiguration.php')) %>
+<%= sanitize_php File.read(File.join(fetch(:local_web_root_path), 'typo3conf', 'AdditionalConfiguration.php')) %>
 <% end %>
 <% if File.exist?(File.join('config', 'typo3', "AdditionalConfiguration.#{fetch(:stage)}.php")) %>
 


### PR DESCRIPTION
This is done to enable using a subdirectory of the release folder as
the web server root.

This relies on https://github.com/dkdeploy/dkdeploy-core/pull/48 to be merged, so that `public_path` is available.