### PR TITLE
[TASK] use remote_web_root_path for path construction

### DIFF
--- a/lib/dkdeploy/typo3/cms/helpers/cli.rb
+++ b/lib/dkdeploy/typo3/cms/helpers/cli.rb
@@ -10,7 +10,7 @@ module Dkdeploy
           # @return [Boolean] returns true/false as success of execution
           def typo3_cli(*cli_params)
             path_to_cli_dispatch = File.join(current_path, fetch(:path_to_typo3_cli))
-            run_script(current_path, path_to_cli_dispatch, cli_params)
+            run_script(File.join(current_path), path_to_cli_dispatch, cli_params)
           end
 
           # Execute a task typo3/cli_dispatch.phpsh cli_params in a specific directory
@@ -33,7 +33,7 @@ module Dkdeploy
           # @return [String] returns the last result of executing task
           def capture_typo3_cli_in_loop(maximum_loop_count, *cli_params, &block)
             path_to_cli_dispatch = File.join(current_path, fetch(:path_to_typo3_cli))
-            capture_script_in_loop(current_path, path_to_cli_dispatch, maximum_loop_count, cli_params, &block)
+            capture_script_in_loop(File.join(current_path), path_to_cli_dispatch, maximum_loop_count, cli_params, &block)
           end
 
           # Returns the last results of invocations of a task typo3/cli_dispatch.phpsh cli_params
@@ -56,7 +56,7 @@ module Dkdeploy
           # @return [Boolean] returns true/false as success of execution
           def typo3_console(*cli_params)
             path_to_typo3_console = File.join(current_path, fetch(:path_to_typo3_console))
-            run_script(current_path, path_to_typo3_console, cli_params)
+            run_script(File.join(current_path), path_to_typo3_console, cli_params)
           end
 
           # Execute a typo3_console task with cli_params in a specific directory
@@ -79,7 +79,7 @@ module Dkdeploy
           # @return [String] returns the last result of executing task
           def capture_typo3_console_in_loop(maximum_loop_count, *cli_params, &block)
             path_to_typo3_console = File.join(current_path, fetch(:path_to_typo3_console))
-            capture_script_in_loop(current_path, path_to_typo3_console, maximum_loop_count, cli_params, &block)
+            capture_script_in_loop(File.join(current_path), path_to_typo3_console, maximum_loop_count, cli_params, &block)
           end
 
           # Returns the last results of invocations of a typo3_console task with cli_params

--- a/lib/dkdeploy/typo3/cms/tasks/cache.rake
+++ b/lib/dkdeploy/typo3/cms/tasks/cache.rake
@@ -5,8 +5,10 @@ namespace :typo3 do
     namespace :cache do
       desc 'Clear TYPO3 file cache directory'
       task :clear_file_cache do |task|
+        remote_web_root_path = fetch(:remote_web_root_path, '.')
+
         on release_roles :app do
-          cache_path = File.join release_path, 'typo3temp', 'var', 'Cache'
+          cache_path = File.join release_path, remote_web_root_path, 'typo3temp', 'var', 'Cache'
           execute :rm, '-rf', cache_path if test "[ -d #{cache_path} ]"
         end
 

--- a/lib/dkdeploy/typo3/cms/tasks/typoscript.rake
+++ b/lib/dkdeploy/typo3/cms/tasks/typoscript.rake
@@ -10,13 +10,14 @@ namespace :typo3 do
       desc "Uploads TypoScript config files from local paths prefixed by variable 'copy_source'"
       task :upload_configs, :copy_source, :typoscript_config_paths, :typoscript_config_file do |_, args|
         prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
         paths       = ask_array_variable(args, :typoscript_config_paths, 'tasks.typoscript.config_paths') { |question| question.default = '' }
         config_file = ask_variable(args, :typoscript_config_file, 'tasks.typoscript.config_file') { |question| question.default = 'config.txt' }
 
         paths.each do |path|
           local_path         = File.join(prefix, path)
           local_config_file  = File.join(local_path, config_file)
-          remote_path        = File.join(current_path, path)
+          remote_path        = File.join(current_path, remote, path)
           remote_config_file = File.join(remote_path, config_file)
 
           unless File.exist? local_config_file
@@ -38,13 +39,14 @@ namespace :typo3 do
       desc "Uploads PageTS files from local paths prefixed by variable 'copy_source'"
       task :upload_pagets, :copy_source, :typoscript_pagets_paths, :typoscript_pagets_file do |_, args|
         prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
         paths       = ask_array_variable(args, :typoscript_pagets_paths, 'tasks.typoscript.pagets_paths') { |question| question.default = '' }
         pagets_file = ask_variable(args, :typoscript_pagets_file, 'tasks.typoscript.pagets_file') { |question| question.default = 'PageTS.txt' }
 
         paths.each do |path|
           local_path         = File.join(prefix, path)
           local_pagets_file  = File.join(local_path, pagets_file)
-          remote_path        = File.join(current_path, path)
+          remote_path        = File.join(current_path, remote, path)
           remote_pagets_file = File.join(remote_path, pagets_file)
 
           unless File.exist? local_pagets_file
@@ -66,13 +68,14 @@ namespace :typo3 do
       desc "Uploads UserTS files from local paths prefixed by variable 'copy_source'"
       task :upload_userts, :copy_source, :typoscript_userts_paths, :typoscript_userts_file do |_, args|
         prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
         paths       = ask_array_variable(args, :typoscript_userts_paths, 'tasks.typoscript.userts_paths') { |question| question.default = '' }
         userts_file = ask_variable(args, :typoscript_userts_file, 'tasks.typoscript.userts_file') { |question| question.default = 'UserTS.txt' }
 
         paths.each do |path|
           local_path         = File.join(prefix, path)
           local_userts_file  = File.join(local_path, userts_file)
-          remote_path        = File.join(current_path, path)
+          remote_path        = File.join(current_path, remote, path)
           remote_userts_file = File.join(remote_path, userts_file)
 
           unless File.exist? local_userts_file
@@ -93,8 +96,9 @@ namespace :typo3 do
 
       desc 'Uploads all config files from given base path'
       task :upload_config_from_base_path, :copy_source, :typoscript_config_base_path, :typoscript_config_file do |_, args|
-        prefix = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
-        base_path = ask_variable(args, :typoscript_config_base_path, 'tasks.typoscript.typoscript_config_base_path') { |question| question.default = '.' }
+        prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_config_base_path, 'tasks.typoscript.typoscript_config_base_path') { |question| question.default = '.' }
         config_file = ask_variable(args, :typoscript_config_file, 'tasks.typoscript.config_file') { |question| question.default = 'config.txt' }
 
         config_files = Dir[File.join(prefix, base_path, '**', config_file).to_s].map { |path_for_config_file| Pathname.new(path_for_config_file).relative_path_from(Pathname.new(prefix)).dirname.to_s }
@@ -102,6 +106,7 @@ namespace :typo3 do
         next if config_files.empty?
 
         set :copy_source, prefix
+        set :remote_web_root_path, remote
         set :typoscript_config_paths, config_files
         set :typoscript_config_file, config_file
         invoke 'typo3:cms:typoscript:upload_configs'
@@ -109,14 +114,16 @@ namespace :typo3 do
 
       desc 'Uploads all PageTS files from given base path'
       task :upload_pagets_from_base_path, :copy_source, :typoscript_pagets_base_path, :typoscript_pagets_file do |_, args|
-        prefix = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
-        base_path = ask_variable(args, :typoscript_pagets_base_path, 'tasks.typoscript.typoscript_pagets_base_path') { |question| question.default = '.' }
+        prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_pagets_base_path, 'tasks.typoscript.typoscript_pagets_base_path') { |question| question.default = '.' }
         pagets_file = ask_variable(args, :typoscript_pagets_file, 'tasks.typoscript.pagets_file') { |question| question.default = 'PageTS.txt' }
 
         pagets_files = Dir[File.join(prefix, base_path, '**', pagets_file).to_s].map { |path_for_pagets_file| Pathname.new(path_for_pagets_file).relative_path_from(Pathname.new(prefix)).dirname.to_s }
         next if pagets_files.empty?
 
         set :copy_source, prefix
+        set :remote_web_root_path, remote
         set :typoscript_pagets_paths, pagets_files
         set :typoscript_pagets_file, pagets_file
         invoke 'typo3:cms:typoscript:upload_pagets'
@@ -124,14 +131,16 @@ namespace :typo3 do
 
       desc 'Uploads all UserTS files from given base path'
       task 'upload_userts_from_base_path', :copy_source, :typoscript_userts_base_path, :typoscript_userts_file do |_, args|
-        prefix = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
-        base_path = ask_variable(args, :typoscript_userts_base_path, 'tasks.typoscript.typoscript_userts_base_path') { |question| question.default = '.' }
+        prefix      = ask_variable(args, :copy_source, 'tasks.typoscript.copy_source') { |question| question.default = 'htdocs' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_userts_base_path, 'tasks.typoscript.typoscript_userts_base_path') { |question| question.default = '.' }
         userts_file = ask_variable(args, :typoscript_userts_file, 'tasks.typoscript.userts_file') { |question| question.default = 'UserTS.txt' }
 
         userts_files = Dir[File.join(prefix, base_path, '**', userts_file).to_s].map { |path_for_userts_file| Pathname.new(path_for_userts_file).relative_path_from(Pathname.new(prefix)).dirname.to_s }
         next if userts_files.empty?
 
         set :copy_source, prefix
+        set :remote_web_root_path, remote
         set :typoscript_userts_paths, userts_files
         set :typoscript_userts_file, userts_file
         invoke 'typo3:cms:typoscript:upload_userts'
@@ -139,11 +148,12 @@ namespace :typo3 do
 
       desc 'Merge remote TypoScript config files'
       task :merge_configs, :typoscript_config_paths, :typoscript_config_file do |_, args|
-        paths = ask_array_variable(args, :typoscript_config_paths, 'tasks.typoscript.config_paths')
+        remote      = fetch(:remote_web_root_path, '.')
+        paths       = ask_array_variable(args, :typoscript_config_paths, 'tasks.typoscript.config_paths')
         config_file = ask_variable(args, :typoscript_config_file, 'tasks.typoscript.config_file') { |question| question.default = 'config.txt' }
 
         paths.each do |path|
-          path = File.join(release_path, path)
+          path = File.join(release_path, remote, path)
 
           target_config_file_with_stage_name = config_file.split('.').join(".#{fetch(:stage)}.")
           source_config_file = File.join(path, 'Stages', target_config_file_with_stage_name)
@@ -169,11 +179,12 @@ namespace :typo3 do
 
       desc 'Merge remote PageTS files'
       task :merge_pagets, :typoscript_pagets_paths, :typoscript_pagets_file do |_, args|
-        paths = ask_array_variable(args, :typoscript_pagets_paths, 'tasks.typoscript.pagets_paths')
+        remote      = fetch(:remote_web_root_path, '.')
+        paths       = ask_array_variable(args, :typoscript_pagets_paths, 'tasks.typoscript.pagets_paths')
         pagets_file = ask_variable(args, :typoscript_pagets_file, 'tasks.typoscript.pagets_file') { |question| question.default = 'PageTS.txt' }
 
         paths.each do |path|
-          path = File.join(release_path, path)
+          path = File.join(release_path, remote, path)
 
           target_pagets_file_with_stage_name = pagets_file.split('.').join(".#{fetch(:stage)}.")
           source_pagets_file = File.join(path, 'Stages', target_pagets_file_with_stage_name)
@@ -199,11 +210,12 @@ namespace :typo3 do
 
       desc 'Merge remote UserTS files'
       task :merge_userts, :typoscript_userts_paths, :typoscript_userts_file do |_, args|
-        paths = ask_array_variable(args, :typoscript_userts_paths, 'tasks.typoscript.userts_paths')
+        remote      = fetch(:remote_web_root_path, '.')
+        paths       = ask_array_variable(args, :typoscript_userts_paths, 'tasks.typoscript.userts_paths')
         userts_file = ask_variable(args, :typoscript_userts_file, 'tasks.typoscript.userts_file') { |question| question.default = 'UserTS.txt' }
 
         paths.each do |path|
-          path = File.join(release_path, path)
+          path = File.join(release_path, remote, path)
 
           target_userts_file_with_stage_name = userts_file.split('.').join(".#{fetch(:stage)}.")
           source_userts_file = File.join(path, 'Stages', target_userts_file_with_stage_name)
@@ -229,13 +241,14 @@ namespace :typo3 do
 
       desc 'Merge all remote config files for a given base path'
       task :merge_config_in_base_path, :typoscript_config_base_path, :typoscript_config_file do |_, args|
-        base_path = ask_variable(args, :typoscript_config_base_path, 'tasks.typoscript.typoscript_config_base_path') { |question| question.default = '.' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_config_base_path, 'tasks.typoscript.typoscript_config_base_path') { |question| question.default = '.' }
         config_file = ask_variable(args, :typoscript_config_file, 'tasks.typoscript.config_file') { |question| question.default = 'config.txt' }
 
         list_of_files = ''
         target_config_file_with_stage_name = config_file.split('.').join(".#{fetch(:stage)}.")
         on primary :app do
-          list_of_files = capture :find, File.join(release_path, base_path), '-type f', "-name '#{target_config_file_with_stage_name}'"
+          list_of_files = capture :find, File.join(release_path, remote, base_path), '-type f', "-name '#{target_config_file_with_stage_name}'"
         end
 
         next if list_of_files.empty?
@@ -248,13 +261,14 @@ namespace :typo3 do
 
       desc 'Merge all remote PageTS files for a given base path'
       task :merge_pagets_in_base_path, :typoscript_pagets_base_path, :typoscript_pagets_file do |_, args|
-        base_path = ask_variable(args, :typoscript_pagets_base_path, 'tasks.typoscript.typoscript_pagets_base_path') { |question| question.default = '.' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_pagets_base_path, 'tasks.typoscript.typoscript_pagets_base_path') { |question| question.default = '.' }
         pagets_file = ask_variable(args, :typoscript_pagets_file, 'tasks.typoscript.pagets_file') { |question| question.default = 'PageTS.txt' }
 
         list_of_files = ''
         target_pagets_file_with_stage_name = pagets_file.split('.').join(".#{fetch(:stage)}.")
         on primary :app do
-          list_of_files = capture :find, File.join(release_path, base_path), '-type f', "-name '#{target_pagets_file_with_stage_name}'"
+          list_of_files = capture :find, File.join(release_path, remote, base_path), '-type f', "-name '#{target_pagets_file_with_stage_name}'"
         end
 
         next if list_of_files.empty?
@@ -267,17 +281,18 @@ namespace :typo3 do
 
       desc 'Merge all remote UserTS files for a given bbase path'
       task :merge_userts_in_base_path, :typoscript_userts_base_path, :typoscript_userts_file do |_, args|
-        base_path = ask_variable(args, :typoscript_userts_base_path, 'tasks.typoscript.typoscript_userts_base_path') { |question| question.default = '.' }
+        remote      = fetch(:remote_web_root_path, '.')
+        base_path   = ask_variable(args, :typoscript_userts_base_path, 'tasks.typoscript.typoscript_userts_base_path') { |question| question.default = '.' }
         userts_file = ask_variable(args, :typoscript_userts_file, 'tasks.typoscript.userts_file') { |question| question.default = 'UserTS.txt' }
 
         list_of_files = ''
         target_userts_file_with_stage_name = userts_file.split('.').join(".#{fetch(:stage)}.")
         on primary :app do
-          list_of_files = capture :find, File.join(release_path, base_path), '-type f', "-name '#{target_userts_file_with_stage_name}'"
+          list_of_files = capture :find, File.join(release_path, remote, base_path), '-type f', "-name '#{target_userts_file_with_stage_name}'"
         end
 
         next if list_of_files.empty?
-        userts_files = list_of_files.split.map { |file| Pathname.new(file).relative_path_from(Pathname.new(release_path)).dirname.dirname.to_s }
+        userts_files = list_of_files.split.map { |file| Pathname.new(file).relative_path_from(Pathname.new(release_path) + remote).dirname.dirname.to_s }
 
         set :typoscript_userts_paths, userts_files
         set :typoscript_userts_file, userts_file

--- a/vendor/AdditionalConfiguration.php.erb
+++ b/vendor/AdditionalConfiguration.php.erb
@@ -1,7 +1,7 @@
 <?php
-<% if File.exist?(File.join('htdocs', 'typo3conf', 'AdditionalConfiguration.php')) %>
+<% if File.exist?(File.join(fetch(:local_web_root_path), 'typo3conf', 'AdditionalConfiguration.php')) %>
 // Content of default configuration file
-<%= sanitize_php File.read(File.join('htdocs', 'typo3conf', 'AdditionalConfiguration.php')) %>
+<%= sanitize_php File.read(File.join(fetch(:local_web_root_path), 'typo3conf', 'AdditionalConfiguration.php')) %>
 <% end %>
 <% if File.exist?(File.join('config', 'typo3', "AdditionalConfiguration.#{fetch(:stage)}.php")) %>
 


### PR DESCRIPTION
Uses the `remote_web_root_path` to build paths to target folders for typoscript and configuration files. Does __not__ use the `remote_web_root_path` to build the path to the `bin` directory, containing `typo3cms` and other executables, since they are assumed to be in `/bin` inside the current directory.